### PR TITLE
Fix DNS decode robustness and UDP EDNS response handling

### DIFF
--- a/dns-resolver/src/lib.rs
+++ b/dns-resolver/src/lib.rs
@@ -6,4 +6,3 @@ pub mod resolver;
 pub use dns::{DnsError, RecordType, ResourceRecord};
 pub use network::{query, query_tcp, query_udp, ROOT_SERVERS};
 pub use resolver::DnsResolver;
-

--- a/dns-resolver/src/main.rs
+++ b/dns-resolver/src/main.rs
@@ -1,28 +1,24 @@
-mod cache;
-mod dns;
-mod network;
-mod resolver;
-
 use anyhow::Result;
+use dns_resolver::{DnsResolver, RecordType};
 use std::env;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() < 2 {
         eprintln!("Usage: {} <domain> [record_type]", args[0]);
         eprintln!("Example: {} example.com A", args[0]);
         std::process::exit(1);
     }
-    
+
     let domain = &args[1];
     let record_type = if args.len() >= 3 {
-        args[2].parse().unwrap_or(dns::RecordType::A)
+        args[2].parse().unwrap_or(RecordType::A)
     } else {
-        dns::RecordType::A
+        RecordType::A
     };
-    
-    let mut resolver = resolver::DnsResolver::new();
+
+    let mut resolver = DnsResolver::new();
     match resolver.resolve(domain, record_type) {
         Ok(records) => {
             for record in records {
@@ -34,7 +30,6 @@ fn main() -> Result<()> {
             std::process::exit(1);
         }
     }
-    
+
     Ok(())
 }
-


### PR DESCRIPTION
## What changed

### Fixes for overflow / panic
- Fixed panic in DNS decode path:
  - `thread 'main' panicked at src/dns.rs:521:22: range end index 514 out of range for slice of length 512`
- Added strict bounds checks in packet decoding so malformed/truncated packets return `InvalidPacket(...)` instead of panicking:
  - question parsing (`question overflow`)
  - RR header parsing (`rr header overflow`)
  - RDATA slicing (`rdata overflow`)
  - per-type RDATA length validation (A/AAAA/MX/SOA/NS/CNAME/PTR)

### DNS compression decode fix
- Reworked `decode_domain_name` to correctly handle mixed `label + pointer` names (e.g. `www` + pointer to `example.com`).
- Added pointer safety checks:
  - out-of-bounds pointer detection
  - compression loop detection

### UDP size fix (EDNS0)
- Increased UDP receive buffer from `512` to `4096` in `query_udp`.
- This matches EDNS0 payload requested by resolver and fixes decode errors like:
  - `Invalid DNS packet: Failed to decode UDP response: Invalid DNS packet: rdata overflow`

## Clippy and cleanup
- Ran `cargo clippy --all-targets --all-features` and fixed warnings:
  - replaced `needless_range_loop` with iterator-based loop
  - replaced `or_insert_with(Vec::new)` with `or_default()`
  - replaced `single_match` with `if let`
  - removed unused imports in tests
  - introduced test type aliases to reduce `type_complexity` warnings
- Added targeted allows where DNS naming/API semantics are intentional:
  - `#[allow(clippy::upper_case_acronyms)]` for DNS record enums
  - `#[allow(clippy::too_many_arguments)]` for SOA test helper
  - `#[allow(dead_code)]` for `is_authoritative`

## Tests added
- `domain_name_compression_mixed_label_and_pointer_decoding`
- `truncated_rdata_returns_error_not_panic` (uses `catch_unwind` to assert no panic)

## Validation
- `cargo clippy --all-targets --all-features` passes clean.
- Non-network tests pass (`--lib`, `integration_test`, `fuzz_test`).

Fixes #1
