### PR TITLE
used rand to generate random query IDs

### DIFF
--- a/dns-resolver/src/resolver.rs
+++ b/dns-resolver/src/resolver.rs
@@ -4,6 +4,7 @@ use crate::network::{extract_ns_and_glue, pick_ns_server, query, ROOT_SERVERS};
 use std::collections::HashSet;
 use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
+use rand::Rng;
 
 /// ------------------------------------------------------------
 /// Configuration
@@ -258,7 +259,7 @@ impl DnsResolver {
             return Err(DnsError::Timeout);
         }
 
-        let query_id = (start.elapsed().as_millis() & 0xFFFF) as u16;
+        let query_id: u16 = rand::rng().random();
         let request = self.create_query_packet(query_id, domain, record_type)?;
         let mut servers: Vec<String> = ROOT_SERVERS.iter().map(|s| (*s).to_string()).collect();
         let mut visited_ns = HashSet::<String>::new();

--- a/dns-resolver/tests/integration_test.rs
+++ b/dns-resolver/tests/integration_test.rs
@@ -6,6 +6,7 @@ use std::{
 
 use dns_resolver::dns::{RecordClass, RecordData};
 use dns_resolver::{DnsError, DnsResolver, RecordType, ResourceRecord};
+use rand::Rng;
 
 /// ------------------------------------------------------------
 /// Helper functions for creating test records
@@ -1193,4 +1194,13 @@ fn encode_domain_name(out: &mut Vec<u8>, name: &str) {
         out.extend_from_slice(label.as_bytes());
     }
     out.push(0);
+}
+
+
+//test for query ID randomization
+#[test]
+fn test_query_ids_no_collisions() {
+    let ids: std::collections::HashSet<u16> =
+        (0..100).map(|_| rand::rng().random::<u16>()).collect();
+    assert!(ids.len() > 90);
 }


### PR DESCRIPTION
## What I changed 

Fixes for DNS query ID predictability
Fixed deterministic query ID generation in resolver.rs:

`let query_id = (start.elapsed().as_millis() & 0xFFFF) as u16` was time-based and predictable

Replaced with cryptographically random u16 using the rand crate:

`let query_id: u16 = rand::rng().random();`

This eliminates the DNS spoofing/cache poisoning attack vector, where an attacker could guess the query ID from the elapsed time

## Tests added 

- `test_query_ids_no_collisions` generates 100 random query IDs and asserts at least 90 are unique, verifying randomness across the 65,536 possible u16 values

## Validation

- `cargo build` passes clean
- `cargo test test_query_ids_no_collisions` passes

<img width="904" height="166" alt="image" src="https://github.com/user-attachments/assets/a79fa437-8a9b-4702-ada8-e46afe95db53" />

- `cargo test` results 

<img width="774" height="881" alt="image" src="https://github.com/user-attachments/assets/14b8f67f-cd03-467e-a202-6c42ba413ceb" />

- Non-network (network_test) tests pass (integration_test, fuzz_test)
- Network test failures are pre-existing 

Fixes #4