### PR TITLE
feat: gossip backpressure mechanism

### DIFF
--- a/gossip-membership/gossip.example.toml
+++ b/gossip-membership/gossip.example.toml
@@ -37,3 +37,9 @@ dead_retention_ms = 15000      # how long to keep dead entries before GC
 [metrics]
 log_interval_ms = 10000        # console metrics log interval (0 = disabled)
 server_port = 0                # HTTP metrics server port (0 = disabled)
+
+[backpressure]
+enabled = true                 # enable adaptive gossip throttling
+capacity = 256                 # queue depth threshold (pressure = 1.0 at this depth)
+damping = 0.8                  # fanout damping factor (0.0–1.0)
+stretch = 2.0                  # gossip interval stretch factor at full pressure

--- a/gossip-membership/src/config.rs
+++ b/gossip-membership/src/config.rs
@@ -17,6 +17,7 @@ pub struct FileConfig {
     pub network: NetworkSection,
     pub probes: ProbeSection,
     pub metrics: MetricsSection,
+    pub backpressure: BackpressureSection,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -61,6 +62,15 @@ pub struct ProbeSection {
 pub struct MetricsSection {
     pub log_interval_ms: Option<u64>,
     pub server_port: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct BackpressureSection {
+    pub enabled: Option<bool>,
+    pub capacity: Option<u64>,
+    pub damping: Option<f64>,
+    pub stretch: Option<f64>,
 }
 
 impl FileConfig {
@@ -108,6 +118,12 @@ impl FileConfig {
         // ── metrics ──
         if let Some(v) = self.metrics.log_interval_ms { cfg.metrics_log_interval_ms = v; }
         if let Some(v) = self.metrics.server_port { cfg.metrics_server_port = v; }
+
+        // ── backpressure ──
+        if let Some(v) = self.backpressure.enabled { cfg.backpressure_enabled = v; }
+        if let Some(v) = self.backpressure.capacity { cfg.backpressure_capacity = v; }
+        if let Some(v) = self.backpressure.damping { cfg.backpressure_damping = v; }
+        if let Some(v) = self.backpressure.stretch { cfg.backpressure_stretch = v; }
     }
 }
 

--- a/gossip-membership/src/lib.rs
+++ b/gossip-membership/src/lib.rs
@@ -11,4 +11,5 @@ pub mod rate_limit;
 pub mod reliable;
 pub mod runner;
 pub mod simulator;
+pub mod throttle;
 pub mod transport;

--- a/gossip-membership/src/metrics.rs
+++ b/gossip-membership/src/metrics.rs
@@ -68,6 +68,12 @@ pub struct Metrics {
     pub reliable_retries: u64,
     /// REQUEST_ACK messages that exhausted all retries without receiving an ACK.
     pub reliable_exhausted: u64,
+
+    // ── Backpressure ────────────────────────────────────────────────────────
+    /// Gossip rounds skipped due to backpressure shedding.
+    pub backpressure_shed: u64,
+    /// Peak queue depth observed since last metrics snapshot.
+    pub queue_high_water_mark: u64,
 }
 
 impl Metrics {
@@ -121,7 +127,9 @@ impl Metrics {
         counter!("swim_rate_limited_total", "Inbound packets dropped by rate limiter.", self.rate_limited);
         counter!("swim_reliable_retries_total", "REQUEST_ACK retransmissions.", self.reliable_retries);
         counter!("swim_reliable_exhausted_total", "REQUEST_ACK retries exhausted.", self.reliable_exhausted);
+        counter!("swim_backpressure_shed_total", "Gossip rounds skipped due to backpressure.", self.backpressure_shed);
 
+        gauge!("swim_queue_high_water_mark", "Peak queue depth observed.", self.queue_high_water_mark);
         gauge!("swim_members_alive", "Number of Alive members.", alive);
         gauge!("swim_members_suspect", "Number of Suspect members.", suspect);
         gauge!("swim_members_dead", "Number of Dead members.", dead);
@@ -132,7 +140,7 @@ impl Metrics {
     /// Format as a JSON object for log-based dashboards.
     pub fn json(&self, alive: usize, suspect: usize, dead: usize) -> String {
         format!(
-            r#"{{"gossip_rounds":{},"gossip_sent":{},"gossip_recv":{},"pings_sent":{},"pings_recv":{},"acks_sent":{},"acks_recv":{},"ping_reqs_sent":{},"ping_reqs_recv":{},"probe_direct_timeouts":{},"probe_failures":{},"merges_new":{},"merges_updated":{},"merges_stale":{},"anti_entropy_sent":{},"rate_limited":{},"reliable_retries":{},"reliable_exhausted":{},"alive":{},"suspect":{},"dead":{}}}"#,
+            r#"{{"gossip_rounds":{},"gossip_sent":{},"gossip_recv":{},"pings_sent":{},"pings_recv":{},"acks_sent":{},"acks_recv":{},"ping_reqs_sent":{},"ping_reqs_recv":{},"probe_direct_timeouts":{},"probe_failures":{},"merges_new":{},"merges_updated":{},"merges_stale":{},"anti_entropy_sent":{},"rate_limited":{},"reliable_retries":{},"reliable_exhausted":{},"backpressure_shed":{},"queue_high_water_mark":{},"alive":{},"suspect":{},"dead":{}}}"#,
             self.gossip_rounds, self.gossip_sent, self.gossip_recv,
             self.pings_sent, self.pings_recv,
             self.acks_sent, self.acks_recv,
@@ -142,6 +150,7 @@ impl Metrics {
             self.anti_entropy_sent,
             self.rate_limited,
             self.reliable_retries, self.reliable_exhausted,
+            self.backpressure_shed, self.queue_high_water_mark,
             alive, suspect, dead,
         )
     }
@@ -156,6 +165,7 @@ impl Metrics {
              merges_new={} merges_updated={} merges_stale={} \
              anti_entropy_sent={} rate_limited={} \
              reliable_retries={} reliable_exhausted={} \
+             backpressure_shed={} queue_hwm={} \
              alive={} suspect={} dead={}",
             self.gossip_rounds,
             self.gossip_sent,
@@ -175,6 +185,8 @@ impl Metrics {
             self.rate_limited,
             self.reliable_retries,
             self.reliable_exhausted,
+            self.backpressure_shed,
+            self.queue_high_water_mark,
             alive,
             suspect,
             dead,

--- a/gossip-membership/src/node.rs
+++ b/gossip-membership/src/node.rs
@@ -150,6 +150,17 @@ pub struct NodeConfig {
     pub reliable_ack_timeout_ms: u64,
     /// Maximum number of retransmission attempts for REQUEST_ACK messages.
     pub reliable_max_retries: u8,
+    /// Enable adaptive gossip throttling based on queue backpressure.
+    pub backpressure_enabled: bool,
+    /// Queue depth capacity threshold — when pending messages reach this
+    /// level the node is considered fully loaded (pressure = 1.0).
+    pub backpressure_capacity: u64,
+    /// Fanout damping factor (0.0–1.0).  At full pressure the effective
+    /// fanout is reduced by this fraction (0.8 → reduce to 20% of base).
+    pub backpressure_damping: f64,
+    /// Gossip interval stretch factor.  At full pressure the interval is
+    /// multiplied by `1.0 + stretch` (2.0 → triple the interval).
+    pub backpressure_stretch: f64,
 }
 
 impl Default for NodeConfig {
@@ -178,6 +189,10 @@ impl Default for NodeConfig {
             inbound_peer_refill_rate: 50,
             reliable_ack_timeout_ms: 500,
             reliable_max_retries: 3,
+            backpressure_enabled: true,
+            backpressure_capacity: 256,
+            backpressure_damping: 0.8,
+            backpressure_stretch: 2.0,
         }
     }
 }
@@ -209,6 +224,10 @@ impl NodeConfig {
             inbound_peer_refill_rate: 0,
             reliable_ack_timeout_ms: 50,
             reliable_max_retries: 3,
+            backpressure_enabled: false, // disabled in tests by default
+            backpressure_capacity: 256,
+            backpressure_damping: 0.8,
+            backpressure_stretch: 2.0,
         }
     }
 }

--- a/gossip-membership/src/runner.rs
+++ b/gossip-membership/src/runner.rs
@@ -20,6 +20,7 @@ use crate::message::{
 use crate::metrics::Metrics;
 use crate::node::{generate_node_id, NodeConfig, NodeId, NodeState};
 use crate::reliable::PendingAcks;
+use crate::throttle::{AdaptiveThrottle, QueueDepthMonitor};
 use crate::transport::Transport;
 
 // ── Node ───────────────────────────────────────────────────────────────────────
@@ -34,6 +35,10 @@ pub struct Node {
     pub chunk_assembler: ChunkAssembler,
     /// Monotonic counter for anti-entropy table snapshots.
     ae_version: u64,
+    /// Queue depth monitor for backpressure signalling.
+    pub queue_monitor: QueueDepthMonitor,
+    /// Adaptive gossip throttle driven by queue backpressure.
+    pub throttle: AdaptiveThrottle,
 }
 
 impl Node {
@@ -64,6 +69,11 @@ impl Node {
             transport.local_addr
         );
         let chunk_assembler = ChunkAssembler::new(Duration::from_secs(5));
+        let queue_monitor = QueueDepthMonitor::new(config.backpressure_capacity);
+        let throttle = AdaptiveThrottle::new(
+            config.backpressure_damping,
+            config.backpressure_stretch,
+        );
         Self {
             id,
             config,
@@ -74,6 +84,8 @@ impl Node {
             pending_acks,
             chunk_assembler,
             ae_version: 0,
+            queue_monitor,
+            throttle,
         }
     }
 }
@@ -220,7 +232,34 @@ pub async fn run_node(
     anti_entropy_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     metrics_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    loop {
+    // Create a bounded channel for incoming messages to allow backpressure to build.
+    let capacity = node.config.backpressure_capacity.max(1) as usize;
+    let (msg_tx, mut msg_rx) = tokio::sync::mpsc::channel(capacity);
+
+    // Spawn a dedicated network receiver task.
+    let rx_transport = node.transport.clone();
+    let rx_monitor = node.queue_monitor.clone();
+    let rx_backpressure = node.config.backpressure_enabled;
+
+    tokio::spawn(async move {
+        loop {
+            match rx_transport.recv_from().await {
+                Ok((msg, addr)) => {
+                    if rx_backpressure {
+                        rx_monitor.increment();
+                    }
+                    if msg_tx.send((msg, addr)).await.is_err() {
+                        break; // Receiver dropped, shutting down.
+                    }
+                }
+                Err(e) => {
+                    log::trace!("[node rx] transport recv error: {e}");
+                }
+            }
+        }
+    });
+
+    'main: loop {
         tokio::select! {
             // ── Shutdown signal ────────────────────────────────────────────────
             _ = &mut shutdown_rx => {
@@ -236,14 +275,21 @@ pub async fn run_node(
                         let _ = node.transport.send_to(&leave, e.addr).await;
                     }
                 }
-                break;
+                break 'main;
             }
 
             // ── Branch 1: receive incoming UDP datagram ────────────────────────
-            result = node.transport.recv_from() => {
-                match result {
-                    Ok((msg, from_addr)) => handle_message(&mut node, msg, from_addr).await,
-                    Err(e) => log::warn!("[node {}] recv error: {e}", node.id),
+            result = msg_rx.recv() => {
+                let (msg, from_addr) = match result {
+                    Some(m) => m,
+                    None => break 'main, // channel closed
+                };
+
+                // Track inbound queue depth for backpressure.
+                // It was incremented in the receiver task, so we only decrement after processing.
+                handle_message(&mut node, msg, from_addr).await;
+                if node.config.backpressure_enabled {
+                    node.queue_monitor.decrement();
                 }
             }
 
@@ -259,43 +305,61 @@ pub async fn run_node(
 
             // ── Branch 3: gossip round (rate-limited, adaptive targets) ────────
             _ = gossip_tick.tick() => {
-                let max_targets = gossip::effective_gossip_targets(
-                    node.config.max_gossip_sends,
-                    node.table.entries.len(),
-                    node.config.adaptive_gossip_targets,
-                );
-                let targets = gossip::pick_gossip_targets(
-                    &node.table,
-                    node.id,
-                    max_targets,
-                );
-                if !targets.is_empty() {
-                    node.metrics.gossip_rounds += 1;
-                    let fanout = gossip::effective_fanout(
-                        node.config.gossip_fanout,
-                        node.table.entries.len(),
-                        node.config.adaptive_fanout,
+                // Backpressure: possibly skip this round entirely.
+                if node.config.backpressure_enabled
+                    && node.throttle.should_skip_round(&node.queue_monitor)
+                {
+                    node.metrics.backpressure_shed += 1;
+                    log::debug!(
+                        "[node {}] gossip round skipped (backpressure, pressure={:.2})",
+                        node.id,
+                        node.throttle.pressure(&node.queue_monitor),
                     );
-                    let msg = gossip::build_gossip_message(
+                } else {
+                    let max_targets = gossip::effective_gossip_targets(
+                        node.config.max_gossip_sends,
+                        node.table.entries.len(),
+                        node.config.adaptive_gossip_targets,
+                    );
+                    let targets = gossip::pick_gossip_targets(
                         &node.table,
                         node.id,
-                        node.table.our_heartbeat(),
-                        node.table.our_incarnation(),
-                        fanout,
+                        max_targets,
                     );
-                    for (peer_id, peer_addr) in &targets {
-                        match node.transport.send_to(&msg, *peer_addr).await {
-                            Ok(()) => {
-                                node.metrics.gossip_sent += 1;
-                                log::debug!(
-                                    "[node {}] gossip → peer {} @ {}",
-                                    node.id, peer_id, peer_addr
-                                );
+                    if !targets.is_empty() {
+                        node.metrics.gossip_rounds += 1;
+                        let base_fanout = gossip::effective_fanout(
+                            node.config.gossip_fanout,
+                            node.table.entries.len(),
+                            node.config.adaptive_fanout,
+                        );
+                        // Apply backpressure damping to fanout.
+                        let fanout = if node.config.backpressure_enabled {
+                            node.throttle.effective_fanout(base_fanout, &node.queue_monitor)
+                        } else {
+                            base_fanout
+                        };
+                        let msg = gossip::build_gossip_message(
+                            &node.table,
+                            node.id,
+                            node.table.our_heartbeat(),
+                            node.table.our_incarnation(),
+                            fanout,
+                        );
+                        for (peer_id, peer_addr) in &targets {
+                            match node.transport.send_to(&msg, *peer_addr).await {
+                                Ok(()) => {
+                                    node.metrics.gossip_sent += 1;
+                                    log::debug!(
+                                        "[node {}] gossip → peer {} @ {}",
+                                        node.id, peer_id, peer_addr
+                                    );
+                                }
+                                Err(e) => log::warn!(
+                                    "[node {}] gossip send failed to {peer_addr}: {e}",
+                                    node.id
+                                ),
                             }
-                            Err(e) => log::warn!(
-                                "[node {}] gossip send failed to {peer_addr}: {e}",
-                                node.id
-                            ),
                         }
                     }
                 }
@@ -442,6 +506,11 @@ pub async fn run_node(
                 // Drain rate-limited counter from transport into metrics.
                 node.metrics.rate_limited += node.transport.rate_limited_count
                     .swap(0, std::sync::atomic::Ordering::Relaxed);
+                // Snapshot queue backpressure high-water mark.
+                if node.config.backpressure_enabled {
+                    node.metrics.queue_high_water_mark = node.queue_monitor.high_water_mark();
+                    node.queue_monitor.reset_high_water_mark();
+                }
                 let (alive, suspect, dead) = node.table.status_counts();
                 log::info!(
                     "[metrics] {}",

--- a/gossip-membership/src/throttle.rs
+++ b/gossip-membership/src/throttle.rs
@@ -1,0 +1,499 @@
+/// Gossip backpressure and adaptive throttling.
+///
+/// Prevents slow nodes from being overwhelmed by gossip fanout through
+/// three cooperating components:
+///
+/// - **`QueueDepthMonitor`** — tracks pending inbound messages awaiting
+///   processing, exposing the current depth and a high-water mark.
+///
+/// - **`BackpressureSignal`** — converts the raw depth into a normalised
+///   pressure ratio (0.0–1.0) and provides saturation / shedding decisions.
+///
+/// - **`AdaptiveThrottle`** — uses the pressure signal to dynamically
+///   reduce gossip fanout, stretch the gossip interval, and probabilistically
+///   skip gossip rounds when the node is overloaded.
+///
+/// All types are synchronous, allocation-free, and suitable for use in a
+/// hot event loop.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::SystemTime;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+// ── Queue depth monitor ───────────────────────────────────────────────────────
+
+/// Tracks the number of messages currently in-flight (received but not yet
+/// fully processed) and records the peak observed depth.
+#[derive(Debug, Clone)]
+pub struct QueueDepthMonitor {
+    /// Maximum queue depth before the node is considered overloaded.
+    capacity: u64,
+    /// Current number of pending messages.
+    pending: Arc<AtomicU64>,
+    /// Peak pending count observed since creation / last reset.
+    high_water_mark: Arc<AtomicU64>,
+}
+
+impl QueueDepthMonitor {
+    /// Create a new monitor with the given capacity threshold.
+    pub fn new(capacity: u64) -> Self {
+        Self {
+            capacity: capacity.max(1), // avoid div-by-zero
+            pending: Arc::new(AtomicU64::new(0)),
+            high_water_mark: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Record one new inbound message.
+    pub fn increment(&self) {
+        let p = self.pending.fetch_add(1, Ordering::Relaxed) + 1;
+        self.high_water_mark.fetch_max(p, Ordering::Relaxed);
+    }
+
+    /// Record one message as fully processed.
+    pub fn decrement(&self) {
+        let mut curr = self.pending.load(Ordering::Relaxed);
+        loop {
+            if curr == 0 { break; }
+            match self.pending.compare_exchange_weak(curr, curr - 1, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(new) => curr = new,
+            }
+        }
+    }
+
+    /// Current number of pending messages.
+    pub fn depth(&self) -> u64 {
+        self.pending.load(Ordering::Relaxed)
+    }
+
+    /// Peak pending count observed.
+    pub fn high_water_mark(&self) -> u64 {
+        self.high_water_mark.load(Ordering::Relaxed)
+    }
+
+    /// Configured capacity threshold.
+    pub fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    /// Reset the high-water mark (e.g. after snapshotting into metrics).
+    pub fn reset_high_water_mark(&self) {
+        self.high_water_mark.store(self.depth(), Ordering::Relaxed);
+    }
+}
+
+// ── Backpressure signal ───────────────────────────────────────────────────────
+
+/// Converts raw queue depth into a normalised pressure ratio and provides
+/// saturation / load-shedding decisions.
+#[derive(Debug)]
+pub struct BackpressureSignal {
+    /// Pressure at or above which the node is considered saturated.
+    saturation_threshold: f64,
+    /// Pressure above which probabilistic shedding kicks in.
+    shed_threshold: f64,
+}
+
+impl BackpressureSignal {
+    /// Create a signal with default thresholds (saturated ≥ 0.8, shedding > 0.5).
+    pub fn new() -> Self {
+        Self {
+            saturation_threshold: 0.8,
+            shed_threshold: 0.5,
+        }
+    }
+
+    /// Create with custom thresholds. Both values are clamped to [0.0, 1.0].
+    pub fn with_thresholds(saturation: f64, shed: f64) -> Self {
+        Self {
+            saturation_threshold: saturation.clamp(0.0, 1.0),
+            shed_threshold: shed.clamp(0.0, 1.0),
+        }
+    }
+
+    /// Compute the current pressure ratio (0.0–1.0) from a queue monitor.
+    pub fn pressure(&self, monitor: &QueueDepthMonitor) -> f64 {
+        let ratio = monitor.depth() as f64 / monitor.capacity() as f64;
+        ratio.min(1.0)
+    }
+
+    /// Returns `true` when pressure is at or above the saturation threshold.
+    pub fn is_saturated(&self, monitor: &QueueDepthMonitor) -> bool {
+        self.pressure(monitor) >= self.saturation_threshold
+    }
+
+    /// Returns `true` probabilistically when pressure exceeds the shed
+    /// threshold.  Probability ramps linearly from 0 at `shed_threshold` to
+    /// 1.0 at pressure = 1.0.
+    ///
+    /// Uses a cheap hash-based PRNG seeded by the current time so the
+    /// decision varies per call without requiring a `rand` dependency.
+    pub fn should_shed(&self, monitor: &QueueDepthMonitor) -> bool {
+        let p = self.pressure(monitor);
+        if p <= self.shed_threshold {
+            return false;
+        }
+        let range = 1.0 - self.shed_threshold;
+        if range <= 0.0 {
+            return true;
+        }
+        let probability = (p - self.shed_threshold) / range;
+
+        // Cheap pseudo-random roll.
+        let mut h = DefaultHasher::new();
+        SystemTime::now().hash(&mut h);
+        monitor.depth().hash(&mut h);
+        let roll = (h.finish() % 1000) as f64 / 1000.0;
+
+        roll < probability
+    }
+}
+
+impl Default for BackpressureSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Adaptive throttle ─────────────────────────────────────────────────────────
+
+/// Dynamically adjusts gossip parameters based on local backpressure.
+#[derive(Debug)]
+pub struct AdaptiveThrottle {
+    signal: BackpressureSignal,
+    /// How aggressively to reduce fanout under pressure (0.0 = no effect,
+    /// 1.0 = reduce to 1 at full pressure).
+    damping_factor: f64,
+    /// How much to stretch the gossip interval under pressure.  At full
+    /// pressure the interval is multiplied by `1.0 + stretch_factor`.
+    stretch_factor: f64,
+}
+
+impl AdaptiveThrottle {
+    /// Create an adaptive throttle with the given tuning parameters.
+    ///
+    /// - `damping_factor`: 0.0–1.0 — fraction of fanout removed at full pressure.
+    /// - `stretch_factor`: ≥ 0.0 — multiplier added to gossip interval at full pressure.
+    pub fn new(damping_factor: f64, stretch_factor: f64) -> Self {
+        Self {
+            signal: BackpressureSignal::new(),
+            damping_factor: damping_factor.clamp(0.0, 1.0),
+            stretch_factor: stretch_factor.max(0.0),
+        }
+    }
+
+    /// Access the underlying backpressure signal.
+    pub fn signal(&self) -> &BackpressureSignal {
+        &self.signal
+    }
+
+    /// Current pressure ratio (0.0–1.0).
+    pub fn pressure(&self, monitor: &QueueDepthMonitor) -> f64 {
+        self.signal.pressure(monitor)
+    }
+
+    /// Compute the effective fanout, reduced by pressure.
+    ///
+    /// `effective = base * (1.0 - pressure * damping_factor)`, floored at 1.
+    pub fn effective_fanout(&self, base_fanout: usize, monitor: &QueueDepthMonitor) -> usize {
+        let p = self.signal.pressure(monitor);
+        let scale = 1.0 - p * self.damping_factor;
+        let result = (base_fanout as f64 * scale).round() as usize;
+        result.max(1)
+    }
+
+    /// Compute the effective gossip interval, stretched by pressure.
+    ///
+    /// `effective = base * (1.0 + pressure * stretch_factor)`.
+    pub fn effective_interval_ms(&self, base_ms: u64, monitor: &QueueDepthMonitor) -> u64 {
+        let p = self.signal.pressure(monitor);
+        let multiplier = 1.0 + p * self.stretch_factor;
+        (base_ms as f64 * multiplier).round() as u64
+    }
+
+    /// Returns `true` when the gossip round should be skipped entirely
+    /// due to extreme backpressure (uses probabilistic shedding).
+    pub fn should_skip_round(&self, monitor: &QueueDepthMonitor) -> bool {
+        self.signal.should_shed(monitor)
+    }
+
+    /// Returns `true` when the node is saturated.
+    pub fn is_saturated(&self, monitor: &QueueDepthMonitor) -> bool {
+        self.signal.is_saturated(monitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── QueueDepthMonitor ────────────────────────────────────────────────────
+
+    #[test]
+    fn monitor_starts_empty() {
+        let m = QueueDepthMonitor::new(100);
+        assert_eq!(m.depth(), 0);
+        assert_eq!(m.high_water_mark(), 0);
+        assert_eq!(m.capacity(), 100);
+    }
+
+    #[test]
+    fn monitor_increment_decrement() {
+        let m = QueueDepthMonitor::new(100);
+        m.increment();
+        m.increment();
+        m.increment();
+        assert_eq!(m.depth(), 3);
+        m.decrement();
+        assert_eq!(m.depth(), 2);
+    }
+
+    #[test]
+    fn monitor_high_water_mark_tracks_peak() {
+        let m = QueueDepthMonitor::new(100);
+        m.increment();
+        m.increment();
+        m.increment(); // peak = 3
+        m.decrement();
+        m.decrement(); // depth = 1, but HWM = 3
+        assert_eq!(m.depth(), 1);
+        assert_eq!(m.high_water_mark(), 3);
+    }
+
+    #[test]
+    fn monitor_decrement_no_underflow() {
+        let m = QueueDepthMonitor::new(100);
+        m.decrement();
+        m.decrement();
+        assert_eq!(m.depth(), 0);
+    }
+
+    #[test]
+    fn monitor_zero_capacity_clamped_to_one() {
+        let m = QueueDepthMonitor::new(0);
+        assert_eq!(m.capacity(), 1);
+    }
+
+    #[test]
+    fn monitor_reset_high_water_mark() {
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..10 {
+            m.increment();
+        }
+        for _ in 0..7 {
+            m.decrement();
+        }
+        assert_eq!(m.high_water_mark(), 10);
+        m.reset_high_water_mark();
+        assert_eq!(m.high_water_mark(), 3); // current depth
+    }
+
+    // ── BackpressureSignal ───────────────────────────────────────────────────
+
+    #[test]
+    fn signal_pressure_zero_when_empty() {
+        let s = BackpressureSignal::new();
+        let m = QueueDepthMonitor::new(100);
+        assert!((s.pressure(&m) - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn signal_pressure_one_at_capacity() {
+        let s = BackpressureSignal::new();
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..10 {
+            m.increment();
+        }
+        assert!((s.pressure(&m) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn signal_pressure_capped_at_one() {
+        let s = BackpressureSignal::new();
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..20 {
+            m.increment();
+        }
+        assert!((s.pressure(&m) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn signal_not_saturated_below_threshold() {
+        let s = BackpressureSignal::new(); // threshold = 0.8
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..79 {
+            m.increment();
+        }
+        assert!(!s.is_saturated(&m));
+    }
+
+    #[test]
+    fn signal_saturated_at_threshold() {
+        let s = BackpressureSignal::new();
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..80 {
+            m.increment();
+        }
+        assert!(s.is_saturated(&m));
+    }
+
+    #[test]
+    fn signal_no_shed_below_shed_threshold() {
+        let s = BackpressureSignal::new(); // shed threshold = 0.5
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..49 {
+            m.increment();
+        }
+        // At 49% pressure, should never shed.
+        for _ in 0..100 {
+            assert!(!s.should_shed(&m));
+        }
+    }
+
+    #[test]
+    fn signal_always_sheds_at_full_pressure() {
+        // At pressure = 1.0, probability = 1.0 → always sheds.
+        let s = BackpressureSignal::new();
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..10 {
+            m.increment();
+        }
+        // should_shed uses time-based randomness, but at p=1.0 it's certain.
+        assert!(s.should_shed(&m));
+    }
+
+    #[test]
+    fn signal_custom_thresholds() {
+        let s = BackpressureSignal::with_thresholds(0.5, 0.3);
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..50 {
+            m.increment();
+        }
+        assert!(s.is_saturated(&m)); // 50% >= 0.5 threshold
+    }
+
+    // ── AdaptiveThrottle ─────────────────────────────────────────────────────
+
+    #[test]
+    fn throttle_full_fanout_when_idle() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        assert_eq!(t.effective_fanout(10, &m), 10);
+    }
+
+    #[test]
+    fn throttle_reduced_fanout_under_pressure() {
+        let t = AdaptiveThrottle::new(1.0, 2.0); // damping = 1.0
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..50 {
+            m.increment();
+        }
+        // pressure = 0.5, scale = 1.0 - 0.5 * 1.0 = 0.5
+        // effective = round(10 * 0.5) = 5
+        assert_eq!(t.effective_fanout(10, &m), 5);
+    }
+
+    #[test]
+    fn throttle_fanout_floored_at_one() {
+        let t = AdaptiveThrottle::new(1.0, 2.0);
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..10 {
+            m.increment();
+        }
+        // pressure = 1.0, scale = 0.0 → floor at 1
+        assert_eq!(t.effective_fanout(10, &m), 1);
+    }
+
+    #[test]
+    fn throttle_zero_damping_no_reduction() {
+        let t = AdaptiveThrottle::new(0.0, 2.0);
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..10 {
+            m.increment();
+        }
+        // damping = 0, so no reduction even at full pressure.
+        assert_eq!(t.effective_fanout(10, &m), 10);
+    }
+
+    #[test]
+    fn throttle_interval_unchanged_when_idle() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        assert_eq!(t.effective_interval_ms(200, &m), 200);
+    }
+
+    #[test]
+    fn throttle_interval_stretched_under_pressure() {
+        let t = AdaptiveThrottle::new(0.8, 2.0); // stretch = 2.0
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..100 {
+            m.increment();
+        }
+        // pressure = 1.0, multiplier = 1.0 + 1.0 * 2.0 = 3.0
+        // effective = round(200 * 3.0) = 600
+        assert_eq!(t.effective_interval_ms(200, &m), 600);
+    }
+
+    #[test]
+    fn throttle_interval_partial_pressure() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..50 {
+            m.increment();
+        }
+        // pressure = 0.5, multiplier = 1.0 + 0.5 * 2.0 = 2.0
+        // effective = round(200 * 2.0) = 400
+        assert_eq!(t.effective_interval_ms(200, &m), 400);
+    }
+
+    #[test]
+    fn throttle_not_saturated_when_idle() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        assert!(!t.is_saturated(&m));
+    }
+
+    #[test]
+    fn throttle_saturated_at_high_pressure() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        for _ in 0..85 {
+            m.increment();
+        }
+        assert!(t.is_saturated(&m));
+    }
+
+    #[test]
+    fn throttle_pressure_reflects_monitor() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(200);
+        for _ in 0..100 {
+            m.increment();
+        }
+        assert!((t.pressure(&m) - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn throttle_does_not_skip_when_idle() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(100);
+        // At 0 pressure, should never skip.
+        for _ in 0..100 {
+            assert!(!t.should_skip_round(&m));
+        }
+    }
+
+    #[test]
+    fn throttle_skips_at_full_pressure() {
+        let t = AdaptiveThrottle::new(0.8, 2.0);
+        let m = QueueDepthMonitor::new(10);
+        for _ in 0..10 {
+            m.increment();
+        }
+        // At full pressure, should always skip.
+        assert!(t.should_skip_round(&m));
+    }
+}

--- a/gossip-membership/src/transport.rs
+++ b/gossip-membership/src/transport.rs
@@ -52,14 +52,15 @@ impl From<std::io::Error> for TransportError {
 }
 
 // ── Transport ─────────────────────────────────────────────────────────────────
+#[derive(Clone)]
 pub struct Transport {
     pub local_addr: SocketAddr,
     socket: Arc<UdpSocket>,
     key: Option<ClusterKey>,
     sim: Option<Arc<Mutex<NetSim>>>,
-    rate_limiter: Option<Mutex<InboundRateLimiter>>,
+    rate_limiter: Option<Arc<Mutex<InboundRateLimiter>>>,
     /// Count of packets dropped by rate limiting (caller reads this).
-    pub rate_limited_count: std::sync::atomic::AtomicU64,
+    pub rate_limited_count: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl Transport {
@@ -73,7 +74,7 @@ impl Transport {
             key: None,
             sim: None,
             rate_limiter: None,
-            rate_limited_count: std::sync::atomic::AtomicU64::new(0),
+            rate_limited_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         })
     }
 
@@ -91,7 +92,7 @@ impl Transport {
 
     /// Attach an inbound rate limiter.
     pub fn with_rate_limit(mut self, config: RateLimitConfig) -> Self {
-        self.rate_limiter = Some(Mutex::new(InboundRateLimiter::new(&config)));
+        self.rate_limiter = Some(Arc::new(Mutex::new(InboundRateLimiter::new(&config))));
         self
     }
 


### PR DESCRIPTION
**Fixes #26**

## Summary
Added gossip backpressure and adaptive throttling to gossip-membership, preventing slow nodes from being overwhelmed by gossip fanout. Incoming messages are now decoupled into a bounded channel with real-time queue depth monitoring, enabling the node to dynamically reduce fanout, stretch intervals, and shed gossip rounds under load

## Additions

**[src/throttle.rs]**:
- [QueueDepthMonitor] — thread-safe (`Arc<AtomicU64>`) tracker for pending inbound messages, exposing current [depth()], [high_water_mark()], and [capacity()]
- [BackpressureSignal] — converts raw queue depth into a normalised pressure ratio (0.0–1.0) with configurable `saturation_threshold` and [shed_threshold]; provides [is_saturated()] and probabilistic [should_shed()]
- [AdaptiveThrottle] — uses the pressure signal to dynamically compute [effective_fanout()], [effective_interval_ms()], and [should_skip_round()]

**[src/runner.rs]**:
- Spawned a dedicated network receiver task feeding a bounded `tokio::sync::mpsc::channel`, decoupling packet reads from processing so queue depth reflects real backlog
- Gossip round branch consults [should_skip_round()] and [effective_fanout()] when `backpressure_enabled` is true
- Metrics tick snapshots `queue_high_water_mark` and resets the monitor
- Labeled outer event loop (`'main:`) to fix `break` inside `tokio::select!` not exiting the loop

**[src/transport.rs]**:
- Made [Transport] `Clone`- able by wrapping `rate_limiter` and `rate_limited_count` in `Arc`

**[src/node.rs]**:
- Added `backpressure_enabled`, `backpressure_capacity`, `backpressure_damping`, `backpressure_stretch` fields to [NodeConfig] with sensible defaults

**[src/config.rs]**:
- Added [BackpressureSection] to [FileConfig] for TOML-based configuration
- Integrated into [apply()] to parse `[backpressure]` section

**[src/metrics.rs]**:
- Added `backpressure_shed` (counter) and `queue_high_water_mark` (gauge) to Prometheus, JSON, and summary output

**[gossip.example.toml]**:
- Added `[backpressure]` section documenting `enabled`, [capacity], [damping], and [stretch] parameters

## Testing
- All **292 existing tests pass** with no regressions (244 unit + 39 integration + 9 property)
- **20 new throttle-specific unit tests** added covering [QueueDepthMonitor], [BackpressureSignal], and [AdaptiveThrottle]