### PR TITLE
feat: dns cache visualisation

### DIFF
--- a/dns-resolver/Cargo.toml
+++ b/dns-resolver/Cargo.toml
@@ -7,4 +7,11 @@ edition = "2021"
 anyhow = "1.0"
 rand = "0.9.2"
 thiserror = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+axum = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+tokio-test = "0.4"
 

--- a/dns-resolver/src/bin/dns_server.rs
+++ b/dns-resolver/src/bin/dns_server.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use dns_resolver::server;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+
+    let mut dns_port: u16 = 1053;
+    let mut http_port: u16 = 8080;
+
+    for (i, arg) in args.iter().enumerate() {
+        match arg.as_str() {
+            "--dns-port" => {
+                if let Some(port_str) = args.get(i + 1) {
+                    dns_port = port_str.parse().unwrap_or(1053);
+                }
+            }
+            "--http-port" => {
+                if let Some(port_str) = args.get(i + 1) {
+                    http_port = port_str.parse().unwrap_or(8080);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    server::run_server(dns_port, http_port).await;
+
+    Ok(())
+}

--- a/dns-resolver/src/cache.rs
+++ b/dns-resolver/src/cache.rs
@@ -7,15 +7,27 @@ use std::{
 
 const DEFAULT_CACHE_CAPACITY: usize = 1024;
 
-/// Cached DNS entry (positive or negative)
+#[derive(Debug, Clone)]
+pub struct CacheEntryInfo {
+    pub domain: String,
+    pub record_type: RecordType,
+    pub ttl: u32,
+    pub created_at_secs: u64,
+    pub expires_at_secs: u64,
+    pub is_negative: bool,
+    pub records: Vec<ResourceRecord>,
+}
+
 #[derive(Clone)]
 enum CacheEntry {
     Positive {
         records: Vec<ResourceRecord>,
         expires_at: Instant,
+        created_at: Instant,
     },
     Negative {
         expires_at: Instant,
+        created_at: Instant,
     },
 }
 
@@ -59,14 +71,14 @@ impl DnsCache {
         let key = (name.to_lowercase(), record_type);
         let mut inner = self.inner.write().unwrap();
 
-        // Clone what we need first to avoid borrow conflicts
         let result = match inner.map.get(&key) {
             Some(CacheEntry::Positive {
                 records,
                 expires_at,
+                ..
             }) if *expires_at > Instant::now() => Some(records.clone()),
-            Some(CacheEntry::Negative { expires_at }) if *expires_at > Instant::now() => {
-                Some(Vec::new()) // Negative cache hit
+            Some(CacheEntry::Negative { expires_at, .. }) if *expires_at > Instant::now() => {
+                Some(Vec::new())
             }
             _ => None,
         };
@@ -97,7 +109,6 @@ impl DnsCache {
         self.put_multiple(vec![record]);
     }
 
-    /// Cache homogeneous RRset
     pub fn put_multiple(&self, records: Vec<ResourceRecord>) {
         if records.is_empty() {
             return;
@@ -118,7 +129,8 @@ impl DnsCache {
         }
 
         let min_ttl = valid.iter().map(|r| r.ttl).min().unwrap();
-        let expires_at = Instant::now() + Duration::from_secs(min_ttl as u64);
+        let now = Instant::now();
+        let expires_at = now + Duration::from_secs(min_ttl as u64);
 
         let mut inner = self.inner.write().unwrap();
         inner.insert(
@@ -126,21 +138,28 @@ impl DnsCache {
             CacheEntry::Positive {
                 records: valid,
                 expires_at,
+                created_at: now,
             },
         );
     }
 
-    /// Cache negative response (NXDOMAIN / NODATA)
     pub fn put_negative(&self, name: &str, record_type: RecordType, ttl: u32) {
         if ttl == 0 {
             return;
         }
 
-        let expires_at = Instant::now() + Duration::from_secs(ttl as u64);
+        let now = Instant::now();
+        let expires_at = now + Duration::from_secs(ttl as u64);
         let key = (name.to_lowercase(), record_type);
 
         let mut inner = self.inner.write().unwrap();
-        inner.insert(key, CacheEntry::Negative { expires_at });
+        inner.insert(
+            key,
+            CacheEntry::Negative {
+                expires_at,
+                created_at: now,
+            },
+        );
     }
 
     /// NS lookup with parent fallback
@@ -176,14 +195,81 @@ impl DnsCache {
 
         inner.map.retain(|_, entry| match entry {
             CacheEntry::Positive { expires_at, .. } => *expires_at > now,
-            CacheEntry::Negative { expires_at } => *expires_at > now,
+            CacheEntry::Negative { expires_at, .. } => *expires_at > now,
         });
     }
 
-    /// Cache metrics
     pub fn stats(&self) -> (u64, u64, u64) {
         let inner = self.inner.read().unwrap();
         (inner.hits, inner.misses, inner.evictions)
+    }
+
+    pub fn entries(&self) -> Vec<CacheEntryInfo> {
+        let inner = self.inner.read().unwrap();
+        let now = Instant::now();
+        let mut result = Vec::new();
+
+        for ((domain, record_type), entry) in &inner.map {
+            match entry {
+                CacheEntry::Positive {
+                    records,
+                    expires_at,
+                    created_at,
+                } => {
+                    if *expires_at > now {
+                        let ttl = expires_at
+                            .checked_duration_since(*created_at)
+                            .map(|d| d.as_secs() as u32)
+                            .unwrap_or(0);
+                        let age = now
+                            .checked_duration_since(*created_at)
+                            .map(|d| d.as_secs() as u64)
+                            .unwrap_or(0);
+                        let expires_in = now
+                            .checked_duration_since(*expires_at)
+                            .map(|d| d.as_secs() as u64)
+                            .unwrap_or(0);
+
+                        result.push(CacheEntryInfo {
+                            domain: domain.clone(),
+                            record_type: *record_type,
+                            ttl,
+                            created_at_secs: age,
+                            expires_at_secs: expires_in,
+                            is_negative: false,
+                            records: records.clone(),
+                        });
+                    }
+                }
+                CacheEntry::Negative {
+                    expires_at,
+                    created_at,
+                } => {
+                    if *expires_at > now {
+                        let ttl = expires_at
+                            .checked_duration_since(*created_at)
+                            .map(|d| d.as_secs() as u32)
+                            .unwrap_or(0);
+                        let age = now
+                            .checked_duration_since(*created_at)
+                            .map(|d| d.as_secs() as u64)
+                            .unwrap_or(0);
+
+                        result.push(CacheEntryInfo {
+                            domain: domain.clone(),
+                            record_type: *record_type,
+                            ttl,
+                            created_at_secs: age,
+                            expires_at_secs: 0,
+                            is_negative: true,
+                            records: Vec::new(),
+                        });
+                    }
+                }
+            }
+        }
+
+        result
     }
 }
 
@@ -763,5 +849,105 @@ mod tests {
         let (hits, misses, _) = cache.stats();
         assert_eq!(misses, 1);
         assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn entries_returns_all_active_entries() {
+        let cache = DnsCache::new();
+        cache.put(a("entry1.com", "1.1.1.1", 300));
+        cache.put(a("entry2.com", "2.2.2.2", 300));
+        cache.put(ns("entry3.com", "ns.entry3.com", 300));
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 3);
+        let domains: Vec<_> = entries.iter().map(|e| e.domain.clone()).collect();
+        assert!(domains.contains(&"entry1.com".to_string()));
+        assert!(domains.contains(&"entry2.com".to_string()));
+        assert!(domains.contains(&"entry3.com".to_string()));
+    }
+
+    #[test]
+    fn entries_excludes_expired_entries() {
+        let cache = DnsCache::new();
+        cache.put(a("fresh.com", "1.1.1.1", 300));
+        cache.put(a("expired.com", "2.2.2.2", 1));
+
+        sleep(Duration::from_secs(2));
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].domain, "fresh.com");
+    }
+
+    #[test]
+    fn entries_age_increases_over_time() {
+        let cache = DnsCache::new();
+        cache.put(a("test.com", "1.1.1.1", 300));
+
+        let entries_before = cache.entries();
+        assert_eq!(entries_before.len(), 1);
+        let age_before = entries_before[0].created_at_secs;
+
+        sleep(Duration::from_secs(2));
+
+        let entries_after = cache.entries();
+        assert_eq!(entries_after.len(), 1);
+        let age_after = entries_after[0].created_at_secs;
+
+        assert!(age_after >= age_before + 2);
+    }
+
+    #[test]
+    fn entries_ttl_matches_record_ttl() {
+        let cache = DnsCache::new();
+        cache.put(a("ttl.com", "1.1.1.1", 120));
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].ttl, 120);
+    }
+
+    #[test]
+    fn entries_negative_cache_included() {
+        let cache = DnsCache::new();
+        cache.put_negative("neg.com", RecordType::A, 300);
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].is_negative);
+        assert!(entries[0].records.is_empty());
+    }
+
+    #[test]
+    fn entries_records_data_included() {
+        let cache = DnsCache::new();
+        cache.put(a("data.com", "1.2.3.4", 300));
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].records.is_empty());
+    }
+
+    #[test]
+    fn entries_record_type_included() {
+        let cache = DnsCache::new();
+        cache.put(ns("test.com", "ns.test.com", 300));
+
+        let entries = cache.entries();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].record_type, RecordType::NS);
+    }
+
+    #[test]
+    fn entries_empty_cache_returns_empty() {
+        let cache = DnsCache::new();
+        let entries = cache.entries();
+        assert!(entries.is_empty());
     }
 }

--- a/dns-resolver/src/lib.rs
+++ b/dns-resolver/src/lib.rs
@@ -2,7 +2,9 @@ pub mod cache;
 pub mod dns;
 pub mod network;
 pub mod resolver;
+pub mod server;
 
+pub use cache::{CacheEntryInfo, DnsCache};
 pub use dns::{DnsError, RecordType, ResourceRecord};
 pub use network::{query, query_tcp, query_udp, ROOT_SERVERS};
-pub use resolver::{DnsResolver, GLOBAL_TIMEOUT, MAX_CNAME_DEPTH};
+pub use resolver::{DnsResolver, ResolverMetrics, GLOBAL_TIMEOUT, MAX_CNAME_DEPTH};

--- a/dns-resolver/src/resolver.rs
+++ b/dns-resolver/src/resolver.rs
@@ -1,10 +1,10 @@
-use crate::cache::DnsCache;
+use crate::cache::{CacheEntryInfo, DnsCache};
 use crate::dns::{DnsError, DnsPacket, RecordClass, RecordData, RecordType, ResourceRecord};
 use crate::network::{extract_ns_and_glue, pick_ns_server, query, ROOT_SERVERS};
+use rand::Rng;
 use std::collections::HashSet;
 use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
-use rand::Rng;
 
 /// ------------------------------------------------------------
 /// Configuration
@@ -79,6 +79,11 @@ impl DnsResolver {
         self.cache.get_ns(domain)
     }
 
+    /// Get all cache entries for visualization
+    pub fn cache_entries(&self) -> Vec<CacheEntryInfo> {
+        self.cache.entries()
+    }
+
     /// Create a DNS query packet for a domain and record type.
     /// Includes minimal EDNS0 (OPT record) so root servers accept the query.
     pub fn create_query_packet(
@@ -126,10 +131,10 @@ impl DnsResolver {
         expected_id: u16,
     ) -> Result<DnsPacket, DnsError> {
         let packet = self.parse_response_packet(data)?;
-        if packet.header.id != expected_id{
+        if packet.header.id != expected_id {
             return Err(DnsError::InvalidPacket(format!(
                 "Transaction ID mismatch : got {}, expected {}",
-                packet.header.id,expected_id
+                packet.header.id, expected_id
             )));
         }
         Ok(packet)
@@ -322,7 +327,7 @@ impl DnsResolver {
                     }
                 };
 
-                let packet = match self.parse_response_packet_with_id(&response_bytes,query_id) {
+                let packet = match self.parse_response_packet_with_id(&response_bytes, query_id) {
                     Ok(p) => p,
                     Err(DnsError::NxDomain) => {
                         self.metrics.lock().unwrap().nxdomain_hits += 1;

--- a/dns-resolver/src/server.rs
+++ b/dns-resolver/src/server.rs
@@ -1,0 +1,416 @@
+use axum::{
+    extract::State,
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::{CacheEntryInfo, DnsResolver};
+use crate::dns::{DnsError, RecordData, RecordType};
+
+#[derive(Clone)]
+struct AppState {
+    resolver: Arc<Mutex<DnsResolver>>,
+}
+
+#[derive(Serialize)]
+struct CacheResponse {
+    entries: Vec<CacheEntryResponse>,
+    stats: CacheStats,
+}
+
+#[derive(Serialize)]
+struct CacheEntryResponse {
+    domain: String,
+    record_type: String,
+    ttl: u32,
+    age: u64,
+    expires_in: u64,
+    is_negative: bool,
+    records: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CacheStats {
+    hits: u64,
+    misses: u64,
+    evictions: u64,
+    total_entries: usize,
+}
+
+#[derive(Serialize)]
+struct ResolverMetricsResponse {
+    resolve_calls: u64,
+    cache_hits: u64,
+    cache_misses: u64,
+    cname_follows: u64,
+    nxdomain_hits: u64,
+    servfail_hits: u64,
+}
+
+fn record_data_to_string(data: &RecordData) -> String {
+    match data {
+        RecordData::A(ip) => ip.to_string(),
+        RecordData::NS(ns) => ns.clone(),
+        RecordData::CNAME(cname) => cname.clone(),
+        RecordData::SOA { .. } => "SOA".to_string(),
+        RecordData::MX { exchange, .. } => exchange.clone(),
+        RecordData::TXT(txt) => txt.clone(),
+        RecordData::AAAA(ip) => ip.to_string(),
+        RecordData::PTR(ptr) => ptr.clone(),
+        RecordData::Unknown(_) => "Unknown".to_string(),
+    }
+}
+
+impl From<CacheEntryInfo> for CacheEntryResponse {
+    fn from(info: CacheEntryInfo) -> Self {
+        let records: Vec<String> = info
+            .records
+            .iter()
+            .map(|r| record_data_to_string(&r.data))
+            .collect();
+
+        Self {
+            domain: info.domain,
+            record_type: format!("{:?}", info.record_type),
+            ttl: info.ttl,
+            age: info.created_at_secs,
+            expires_in: info.expires_at_secs,
+            is_negative: info.is_negative,
+            records,
+        }
+    }
+}
+
+async fn get_cache(State(state): State<AppState>) -> impl IntoResponse {
+    let resolver = state.resolver.lock().await;
+    let entries = resolver.cache_entries();
+    let (hits, misses, evictions) = resolver.cache_stats();
+    let total_entries = entries.len();
+
+    let response = CacheResponse {
+        entries: entries.into_iter().map(CacheEntryResponse::from).collect(),
+        stats: CacheStats {
+            hits,
+            misses,
+            evictions,
+            total_entries,
+        },
+    };
+
+    Json(response)
+}
+
+async fn cache_stats(State(state): State<AppState>) -> impl IntoResponse {
+    let resolver = state.resolver.lock().await;
+    let (hits, misses, evictions) = resolver.cache_stats();
+    let entries = resolver.cache_entries();
+
+    Json(serde_json::json!({
+        "hits": hits,
+        "misses": misses,
+        "evictions": evictions,
+        "total_entries": entries.len()
+    }))
+}
+
+async fn resolver_metrics(State(state): State<AppState>) -> impl IntoResponse {
+    let resolver = state.resolver.lock().await;
+    let metrics = resolver.metrics().unwrap();
+
+    Json(ResolverMetricsResponse {
+        resolve_calls: metrics.resolve_calls,
+        cache_hits: metrics.cache_hits,
+        cache_misses: metrics.cache_misses,
+        cname_follows: metrics.cname_follows,
+        nxdomain_hits: metrics.nxdomain_hits,
+        servfail_hits: metrics.servfail_hits,
+    })
+}
+
+async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "status": "ok"
+    }))
+}
+
+async fn resolve_query(State(state): State<AppState>, Json(query): Json<DnsQueryRequest>) -> impl IntoResponse {
+    let mut resolver = state.resolver.lock().await;
+    let record_type: RecordType = query.record_type.and_then(|rt| rt.parse().ok()).unwrap_or(RecordType::A);
+
+    match resolver.resolve(&query.domain, record_type) {
+        Ok(records) => {
+            let response_records: Vec<String> = records.iter()
+                .map(|r| record_data_to_string(&r.data))
+                .collect();
+            Json(serde_json::json!({
+                "domain": query.domain,
+                "record_type": format!("{:?}", record_type),
+                "records": response_records,
+                "cached": false
+            }))
+        }
+        Err(e) => {
+            Json(serde_json::json!({
+                "domain": query.domain,
+                "error": format!("{:?}", e),
+                "records": [],
+            }))
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct DnsQueryRequest {
+    domain: String,
+    record_type: Option<String>,
+}
+
+pub async fn run_http_server(resolver: Arc<Mutex<DnsResolver>>, http_port: u16) {
+    let addr = SocketAddr::from(([0, 0, 0, 0], http_port));
+
+    let app = Router::new()
+        .route("/", get(health))
+        .route("/cache", get(get_cache))
+        .route("/cache/stats", get(cache_stats))
+        .route("/metrics", get(resolver_metrics))
+        .route("/resolve", axum::routing::post(resolve_query))
+        .with_state(AppState { resolver });
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    println!("HTTP API Server running on http://{}", addr);
+    println!("Endpoints:");
+    println!("  GET  /            - Health check");
+    println!("  GET  /cache       - List all cache entries");
+    println!("  GET  /cache/stats - Cache statistics");
+    println!("  GET  /metrics     - Resolver metrics");
+    println!("  POST /resolve     - Resolve domain (body: {{\"domain\": \"example.com\", \"record_type\": \"A\"}})");
+
+    axum::serve(listener, app).await.unwrap();
+}
+
+pub async fn run_dns_server(resolver: Arc<Mutex<DnsResolver>>, dns_port: u16) {
+    let addr = SocketAddr::from(([0, 0, 0, 0], dns_port));
+    let socket = match tokio::net::UdpSocket::bind(addr).await {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            eprintln!("Warning: Failed to bind DNS port {}: {}", dns_port, e);
+            eprintln!("         DNS server will not be available.");
+            eprintln!("         Use --dns-port to try a different port (e.g., --dns-port 1053)");
+            return;
+        }
+    };
+    println!("DNS Server running on udp://{}", addr);
+
+    let mut buf = [0u8; 512];
+
+    loop {
+        let socket_clone = socket.clone();
+        match socket_clone.recv_from(&mut buf).await {
+            Ok((len, client_addr)) => {
+                let resolver = resolver.clone();
+                let socket_for_spawn = socket.clone();
+                let buf_copy = buf[..len].to_vec();
+                
+                tokio::spawn(async move {
+                    handle_dns_query(&resolver, &buf_copy, client_addr, &socket_for_spawn).await;
+                });
+            }
+            Err(e) => {
+                eprintln!("DNS recv error: {}", e);
+            }
+        }
+    }
+}
+
+async fn handle_dns_query(
+    resolver: &Arc<Mutex<DnsResolver>>,
+    buf: &[u8],
+    client_addr: SocketAddr,
+    socket: &tokio::net::UdpSocket,
+) {
+    if buf.len() < 12 {
+        return;
+    }
+
+    let transaction_id = u16::from_be_bytes([buf[0], buf[1]]);
+    let qdcount = u16::from_be_bytes([buf[4], buf[5]]);
+
+    if qdcount == 0 {
+        return;
+    }
+
+    let mut offset = 12;
+    let mut qname = String::new();
+    loop {
+        let label_len = buf[offset];
+        offset += 1;
+        if label_len == 0 {
+            break;
+        }
+        if !qname.is_empty() {
+            qname.push('.');
+        }
+        qname.push(char::from(buf[offset]));
+        qname.push(char::from(buf[offset + 1]));
+        qname.push(char::from(buf[offset + 2]));
+        offset += label_len as usize;
+    }
+    offset += 5;
+
+    let qtype = u16::from_be_bytes([buf[offset - 5], buf[offset - 4]]);
+    let record_type = RecordType::from_u16(qtype).unwrap_or(RecordType::A);
+
+    let mut resolver_guard = resolver.lock().await;
+    let response = match resolver_guard.resolve(&qname, record_type) {
+        Ok(records) => build_dns_response(transaction_id, qdcount, &qname, record_type, &records, 0),
+        Err(DnsError::NxDomain) => build_nxdomain_response(transaction_id, qdcount, &qname, record_type),
+        Err(e) => {
+            eprintln!("DNS resolve error for {}: {:?}", qname, e);
+            build_servfail_response(transaction_id, qdcount, &qname, record_type)
+        }
+    };
+    drop(resolver_guard);
+
+    if let Ok(response) = response {
+        if let Err(e) = socket.send_to(&response, client_addr).await {
+            eprintln!("DNS send error: {}", e);
+        }
+    }
+}
+
+fn build_dns_response(
+    transaction_id: u16,
+    _qdcount: u16,
+    qname: &str,
+    qtype: RecordType,
+    records: &[crate::dns::ResourceRecord],
+    _rcode: u8,
+) -> Result<Vec<u8>, std::io::Error> {
+    let mut buf = Vec::new();
+
+    buf.extend_from_slice(&transaction_id.to_be_bytes());
+    buf.extend_from_slice(&0x8180u16.to_be_bytes());
+    buf.extend_from_slice(&1u16.to_be_bytes());
+    buf.extend_from_slice(&(records.len() as u16).to_be_bytes());
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    buf.extend_from_slice(&0u16.to_be_bytes());
+
+    for label in qname.split('.') {
+        buf.push(label.len() as u8);
+        buf.extend_from_slice(label.as_bytes());
+    }
+    buf.push(0);
+    buf.extend_from_slice(&qtype.to_u16().to_be_bytes());
+    buf.extend_from_slice(&1u16.to_be_bytes());
+
+    for record in records {
+        if let Ok(encoded) = record_encode(record) {
+            buf.extend_from_slice(&encoded);
+        }
+    }
+
+    Ok(buf)
+}
+
+fn record_encode(record: &crate::dns::ResourceRecord) -> Result<Vec<u8>, std::io::Error> {
+    let mut buf = Vec::new();
+
+    if record.name.contains('.') {
+        for label in record.name.split('.') {
+            buf.push(label.len() as u8);
+            buf.extend_from_slice(label.as_bytes());
+        }
+    } else {
+        buf.extend_from_slice(record.name.as_bytes());
+    }
+    buf.push(0);
+
+    buf.extend_from_slice(&record.record_type.to_u16().to_be_bytes());
+    buf.extend_from_slice(&1u16.to_be_bytes());
+    buf.extend_from_slice(&record.ttl.to_be_bytes());
+
+    match &record.data {
+        RecordData::A(ip) => {
+            buf.extend_from_slice(&4u16.to_be_bytes());
+            buf.extend_from_slice(&ip.octets());
+        }
+        RecordData::AAAA(ip) => {
+            buf.extend_from_slice(&16u16.to_be_bytes());
+            let segments = ip.segments();
+            let mut bytes = Vec::with_capacity(16);
+            for &seg in &segments {
+                bytes.extend_from_slice(&seg.to_be_bytes());
+            }
+            buf.extend_from_slice(&bytes);
+        }
+        RecordData::NS(s) | RecordData::CNAME(s) | RecordData::PTR(s) => {
+            let mut name_buf = Vec::new();
+            for label in s.split('.') {
+                name_buf.push(label.len() as u8);
+                name_buf.extend_from_slice(label.as_bytes());
+            }
+            name_buf.push(0);
+            buf.extend_from_slice(&(name_buf.len() as u16).to_be_bytes());
+            buf.extend_from_slice(&name_buf);
+        }
+        RecordData::MX { exchange, .. } => {
+            let mut name_buf = Vec::new();
+            for label in exchange.split('.') {
+                name_buf.push(label.len() as u8);
+                name_buf.extend_from_slice(label.as_bytes());
+            }
+            name_buf.push(0);
+            buf.extend_from_slice(&(name_buf.len() as u16 + 2).to_be_bytes());
+            buf.extend_from_slice(&0u16.to_be_bytes());
+            buf.extend_from_slice(&name_buf);
+        }
+        RecordData::TXT(txt) => {
+            buf.extend_from_slice(&((txt.len() + 1) as u16).to_be_bytes());
+            buf.push(txt.len() as u8);
+            buf.extend_from_slice(txt.as_bytes());
+        }
+        _ => {
+            buf.extend_from_slice(&0u16.to_be_bytes());
+        }
+    }
+
+    Ok(buf)
+}
+
+fn build_nxdomain_response(transaction_id: u16, _qdcount: u16, qname: &str, qtype: RecordType) -> Result<Vec<u8>, std::io::Error> {
+    build_dns_response(transaction_id, 1, qname, qtype, &[], 3)
+}
+
+fn build_servfail_response(transaction_id: u16, _qdcount: u16, qname: &str, qtype: RecordType) -> Result<Vec<u8>, std::io::Error> {
+    build_dns_response(transaction_id, 1, qname, qtype, &[], 2)
+}
+
+pub async fn run_server(dns_port: u16, http_port: u16) {
+    let resolver = Arc::new(Mutex::new(DnsResolver::new()));
+
+    let dns_resolver = resolver.clone();
+    let http_resolver = resolver.clone();
+
+    let dns_handle = tokio::spawn(async move {
+        run_dns_server(dns_resolver, dns_port).await;
+    });
+
+    let http_handle = tokio::spawn(async move {
+        run_http_server(http_resolver, http_port).await;
+    });
+
+    println!("DNS Cache Server started");
+    println!("  DNS:  udp://0.0.0.0:{}", dns_port);
+    println!("  HTTP: http://0.0.0.0:{}", http_port);
+    println!();
+
+    tokio::select! {
+        _ = dns_handle => {}
+        _ = http_handle => {}
+    }
+}


### PR DESCRIPTION
Fixes #38

## Summary
Implemented DNS Cache Visualization API, exposing cache entries via HTTP endpoint for monitoring and debugging DNS resolution activity.

## Additions
HTTP API Endpoints
- GET /cache - Returns all cached DNS entries
- GET /cache/stats - Cache statistics (hits, misses, evictions)
- GET /metrics - Resolver metrics
- POST /resolve - HTTP-based DNS resolution

DNS Server
- DNS UDP server on port 1053 (configurable via --dns-port)
- HTTP API server on port 8080 (configurable via --http-port)
- Both share single DnsResolver instance with unified cache
`/cache` Response Format
```
{
  "entries": [
    {
      "domain": "example.com",
      "record_type": "A",
      "ttl": 300,
      "age": 45,
      "expires_in": 255,
      "is_negative": false,
      "records": ["93.184.216.34"]
    }
  ],
  "stats": {
    "hits": 0,
    "misses": 1,
    "evictions": 0,
    "total_entries": 33
  }
}
```
- Usage
```
# Start server
cargo run --bin dns_server
# Query DNS
dig @127.0.0.1 -p 1053 example.com
```

## Tests
- Added 8 tests for cache entry visualization
- All 58 tests pass.